### PR TITLE
fix(github): handle gists with api

### DIFF
--- a/src/functions/github/regex.ts
+++ b/src/functions/github/regex.ts
@@ -2,6 +2,6 @@
 export const NormalGitHubUrlRegex =
 	/https:\/\/github\.com\/(?<org>.+?)\/(?<repo>.+?)\/(?:(?:blob)|(?:blame))(?<path>\/[^\s#>]+)(?<opts>[^\s>]+)?/;
 
-export const GistGitHubUrlRegex = /https:\/\/gist\.github\.com\/(?<user>.+?)\/(?<id>[^\s#>]+)#file-(?<opts>[^\s>]+)/;
+export const GistGitHubUrlRegex = /https:\/\/gist\.github\.com\/.*\/(?<id>[^\s#>]+)#file-(?<opts>[^\s>]+)/;
 
 export const GitHubUrlLinesRegex = /[#-]?[LR](?<start>(?:\d|[^\n->])+)?(?:-[LR](?<end>\d+))?/;

--- a/src/functions/github/utils.ts
+++ b/src/functions/github/utils.ts
@@ -60,7 +60,7 @@ export function validateFileSize(file: Buffer) {
 }
 
 export function resolveFileLanguage(url: string) {
-	return url!.split(".").pop()?.replace(GitHubUrlLinesRegex, "") ?? "ansi";
+	return url.split(".").pop()?.replace(GitHubUrlLinesRegex, "") ?? "ansi";
 }
 
 export function generateHeader(options: GenerateHeaderOptions): string {


### PR DESCRIPTION
Handle gists with API instead of gist.githubusercontent.com, because the links are not consistent for gist.githubusercontent.com.
Still needs some cleaning up